### PR TITLE
Expose subscription price attribute

### DIFF
--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -95,6 +95,12 @@ class Subscription(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         cascade="all, delete-orphan",
     )
 
+    @property
+    def price(self) -> Decimal:
+        """Expose price value for serialization layers."""
+
+        return self.price_numeric
+
 
 class Notification(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     """Notification entity."""


### PR DESCRIPTION
## Summary
- expose the subscription price via a read-only property so API responses include the expected field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d38d6e47b083318e5a5c6409792761